### PR TITLE
Fixes invalid datafile issue

### DIFF
--- a/lib/optimizely.rb
+++ b/lib/optimizely.rb
@@ -343,6 +343,12 @@ module Optimizely
       # Returns the string variable value.
       # Returns nil if the feature flag or variable are not found.
 
+      unless @is_valid
+        logger = SimpleLogger.new
+        logger.log(Logger::ERROR, InvalidDatafileError.new('get_feature_variable_string').message)
+        return nil
+      end
+
       variable_value = get_feature_variable_for_type(
         feature_flag_key,
         variable_key,
@@ -364,6 +370,12 @@ module Optimizely
       #
       # Returns the boolean variable value.
       # Returns nil if the feature flag or variable are not found.
+
+      unless @is_valid
+        logger = SimpleLogger.new
+        logger.log(Logger::ERROR, InvalidDatafileError.new('get_feature_variable_boolean').message)
+        return false
+      end
 
       variable_value = get_feature_variable_for_type(
         feature_flag_key,
@@ -387,6 +399,12 @@ module Optimizely
       # Returns the double variable value.
       # Returns nil if the feature flag or variable are not found.
 
+      unless @is_valid
+        logger = SimpleLogger.new
+        logger.log(Logger::ERROR, InvalidDatafileError.new('get_feature_variable_double').message)
+        return nil
+      end
+
       variable_value = get_feature_variable_for_type(
         feature_flag_key,
         variable_key,
@@ -408,6 +426,12 @@ module Optimizely
       #
       # Returns the integer variable value.
       # Returns nil if the feature flag or variable are not found.
+
+      unless @is_valid
+        logger = SimpleLogger.new
+        logger.log(Logger::ERROR, InvalidDatafileError.new('get_feature_variable_integer').message)
+        return nil
+      end
 
       variable_value = get_feature_variable_for_type(
         feature_flag_key,

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -893,6 +893,17 @@ describe 'Optimizely' do
     user_id = 'test_user'
     user_attributes = {}
 
+    it 'should return nil when called with invalid project config' do
+      logger = double('logger')
+      allow(logger).to receive(:log)
+      allow(Optimizely::SimpleLogger).to receive(:new) { logger }
+      invalid_project = Optimizely::Project.new('invalid', nil, spy_logger)
+      expect(invalid_project.get_feature_variable_string('string_single_variable_feature', 'string_variable', user_id, user_attributes))
+        .to eq(nil)
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format.')
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format. Aborting get_feature_variable_string.')
+    end
+
     describe 'when the feature flag is enabled for the user' do
       describe 'and a variable usage instance is not found' do
         it 'should return the default variable value' do
@@ -1027,6 +1038,17 @@ describe 'Optimizely' do
     user_id = 'test_user'
     user_attributes = {}
 
+    it 'should return false when called with invalid project config' do
+      logger = double('logger')
+      allow(logger).to receive(:log)
+      allow(Optimizely::SimpleLogger).to receive(:new) { logger }
+      invalid_project = Optimizely::Project.new('invalid', nil, spy_logger)
+      expect(invalid_project.get_feature_variable_boolean('boolean_single_variable_feature', 'boolean_variable', user_id, user_attributes))
+        .to eq(false)
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format.')
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format. Aborting get_feature_variable_boolean.')
+    end
+
     it 'should return the variable value for the variation for the user is bucketed into' do
       boolean_feature = project_instance.config.feature_flag_key_map['boolean_single_variable_feature']
       rollout = project_instance.config.rollout_id_map[boolean_feature['rolloutId']]
@@ -1052,6 +1074,17 @@ describe 'Optimizely' do
   describe '#get_feature_variable_double' do
     user_id = 'test_user'
     user_attributes = {}
+
+    it 'should return nil when called with invalid project config' do
+      logger = double('logger')
+      allow(logger).to receive(:log)
+      allow(Optimizely::SimpleLogger).to receive(:new) { logger }
+      invalid_project = Optimizely::Project.new('invalid', nil, spy_logger)
+      expect(invalid_project.get_feature_variable_double('double_single_variable_feature', 'double_variable', user_id, user_attributes))
+        .to eq(nil)
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format.')
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format. Aborting get_feature_variable_double.')
+    end
 
     it 'should return the variable value for the variation for the user is bucketed into' do
       double_feature = project_instance.config.feature_flag_key_map['double_single_variable_feature']
@@ -1079,6 +1112,17 @@ describe 'Optimizely' do
   describe '#get_feature_variable_integer' do
     user_id = 'test_user'
     user_attributes = {}
+
+    it 'should return nil when called with invalid project config' do
+      logger = double('logger')
+      allow(logger).to receive(:log)
+      allow(Optimizely::SimpleLogger).to receive(:new) { logger }
+      invalid_project = Optimizely::Project.new('invalid', nil, spy_logger)
+      expect(invalid_project.get_feature_variable_integer('integer_single_variable_feature', 'integer_variable', user_id, user_attributes))
+        .to eq(nil)
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format.')
+      expect(logger).to have_received(:log).once.with(Logger::ERROR, 'Provided datafile is in an invalid format. Aborting get_feature_variable_integer.')
+    end
 
     it 'should return the variable value for the variation for the user is bucketed into' do
       integer_feature = project_instance.config.feature_flag_key_map['integer_single_variable_feature']


### PR DESCRIPTION
**Note:** We could have placed general validation check in `get_feature_variable_for_type` method
but due to API method name in error log message, 
`logger.log(Logger::ERROR, InvalidDatafileError.new('get_feature_variable_integer').message)`
it's written separately.

Other solution is to get _caller method name_ by `caller.first[/`(.*)'/, 1]`
`logger.log(Logger::ERROR, InvalidDatafileError.new(caller.first[/`(.*)'/, 1]).message)`
In this case there is no need to check separately.