### PR TITLE
Fix(set-forced-variation): Treats empty variation key as invalid and does not reset variation.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Naming/VariableNumber:
 Style/Documentation:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/RescueStandardError:
    Enabled: false
 

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -330,7 +330,7 @@ module Optimizely
       # Returns a boolean value that indicates if the set completed successfully.
 
       input_values = {user_id: user_id, experiment_key: experiment_key}
-      input_values[:variation_key] = variation_key if variation_key
+      input_values[:variation_key] = variation_key unless variation_key.nil?
       return false unless Optimizely::Helpers::Validator.inputs_valid?(input_values, @logger, Logger::DEBUG)
 
       experiment = get_experiment_from_key(experiment_key)

--- a/lib/optimizely/project_config.rb
+++ b/lib/optimizely/project_config.rb
@@ -329,12 +329,9 @@ module Optimizely
       #
       # Returns a boolean value that indicates if the set completed successfully.
 
-      return false unless Optimizely::Helpers::Validator.inputs_valid?(
-        {
-          user_id: user_id,
-          experiment_key: experiment_key
-        }, @logger, Logger::DEBUG
-      )
+      input_values = {user_id: user_id, experiment_key: experiment_key}
+      input_values[:variation_key] = variation_key if variation_key
+      return false unless Optimizely::Helpers::Validator.inputs_valid?(input_values, @logger, Logger::DEBUG)
 
       experiment = get_experiment_from_key(experiment_key)
       experiment_id = experiment['id'] if experiment
@@ -342,7 +339,7 @@ module Optimizely
       return false if experiment_id.nil? || experiment_id.empty?
 
       #  clear the forced variation if the variation key is null
-      if variation_key.nil? || variation_key.empty?
+      if variation_key.nil?
         @forced_variation_map[user_id].delete(experiment_id) if @forced_variation_map.key? user_id
         @logger.log(Logger::DEBUG, "Variation mapped to experiment '#{experiment_key}' has been removed for user "\
                     "'#{user_id}'.")

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -927,10 +927,11 @@ describe Optimizely::ProjectConfig do
                                                      "Variation mapped to experiment '#{@valid_experiment[:key]}' has been removed for user '#{@user_id}'.")
     end
     # Variation key is an empty string
-    it 'should delete forced varaition maping, log a message and return true when variation_key is passed as empty string' do
-      expect(config.set_forced_variation(@valid_experiment[:key], @user_id, '')).to eq(true)
+    it 'should return false when variation_key is passed as empty string' do
+      expect(config.set_forced_variation(@valid_experiment[:key], @user_id, '')).to eq(false)
       expect(spy_logger).to have_received(:log).with(Logger::DEBUG,
-                                                     "Variation mapped to experiment '#{@valid_experiment[:key]}' has been removed for user '#{@user_id}'.")
+                                                     'Variation key is invalid')
+      expect(config.get_forced_variation(@valid_experiment[:key], @user_id)).to eq(nil)
     end
     # Variation key does not exist in the datafile
     it 'return false when variation_key is not in datafile' do
@@ -958,7 +959,8 @@ describe Optimizely::ProjectConfig do
       expect(Optimizely::Helpers::Validator).to receive(:inputs_valid?).with(
         {
           user_id: @user_id,
-          experiment_key: @valid_experiment[:key]
+          experiment_key: @valid_experiment[:key],
+          variation_key: @valid_variation[:key]
         }, spy_logger, Logger::DEBUG
       )
       config.set_forced_variation(@valid_experiment[:key], @user_id, @valid_variation[:key])
@@ -985,9 +987,6 @@ describe Optimizely::ProjectConfig do
       variation = config.get_forced_variation(@valid_experiment[:key], @user_id)
       expect(variation['id']).to eq(@valid_variation_2[:id])
       expect(variation['key']).to eq(@valid_variation_2[:key])
-
-      expect(config.set_forced_variation(@valid_experiment[:key], @user_id, '')).to eq(true)
-      expect(config.get_forced_variation(@valid_experiment[:key], @user_id)).to eq(nil)
     end
 
     # Set variation on multiple experiments for one user.

--- a/spec/project_config_spec.rb
+++ b/spec/project_config_spec.rb
@@ -927,7 +927,7 @@ describe Optimizely::ProjectConfig do
                                                      "Variation mapped to experiment '#{@valid_experiment[:key]}' has been removed for user '#{@user_id}'.")
     end
     # Variation key is an empty string
-    it 'should return false when variation_key is passed as empty string' do
+    it 'should persist forced variation mapping, log a message and return false when variation_key is passed as empty string' do
       expect(config.set_forced_variation(@valid_experiment[:key], @user_id, '')).to eq(false)
       expect(spy_logger).to have_received(:log).with(Logger::DEBUG,
                                                      'Variation key is invalid')


### PR DESCRIPTION
## Summary

- Updated rubocop configuration to ignore existing lint errors, which are already fixed in a PR https://github.com/optimizely/ruby-sdk/pull/136
- Forced variation key passed as an empty String will be invalid argument.
- Updated inputs validation for set_forced_variation.
- Updated unit tests for empty string variation key.